### PR TITLE
Suppress logging output if verbose is false

### DIFF
--- a/dist/accesssniff.js
+++ b/dist/accesssniff.js
@@ -217,11 +217,13 @@ var Accessibility = function () {
       // If verbose is true then push the output through to the terminal
       var showMessage = this.errorCount || this.noticeCount || this.warningCount;
 
-      if (showMessage && messageLog.length || this.options.verbose) {
-        _logger2.default.startMessage('Tested ' + this.options.filePath);
-        messageLog.forEach(function (message) {
-          return _logger2.default.generalMessage(message);
-        });
+      if (showMessage && messageLog.length) {
+        if (this.options.verbose) {
+          _logger2.default.startMessage('Tested ' + this.options.filePath);
+          messageLog.forEach(function (message) {
+            return _logger2.default.generalMessage(message);
+          });
+        }
         this.lintFree = false;
       }
 


### PR DESCRIPTION
I was still getting logging output after setting the verbose option to false, as in the code snippet below.  

_AccessSniff.default(files, {
    accessibilityLevel: 'WCAG2AA',
    force: true,
    verbose: false,
    reportType: 'json',
    ignore: [
      'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.1.NoTitleEl',
      'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2'
    ]
  })_

This change fixed it for me, while still maintaining `n files lint free` counter.