### PR TITLE
Add Section508 Level Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ options: {
 }
 ```
 
-Levels are `WCAG2A`, `WCAG2AA`, and `WCAG2AAA`
+Levels are `WCAG2A`, `WCAG2AA`, `WCAG2AAA`, and `Section508` 
 
 ### Accessibilityrc
 

--- a/dist/phantom.js
+++ b/dist/phantom.js
@@ -65,6 +65,11 @@ page.open(url, function () {
         return HTMLCS_RUNNER.run('WCAG2AAA');
       });
       break;
+    case 'Section508':
+      page.evaluate(function () {
+        return HTMLCS_RUNNER.run('Section508');
+      });
+      break;
     default:
       console.log('Unknown standard.');
   }

--- a/src/phantom.js
+++ b/src/phantom.js
@@ -58,6 +58,9 @@ page.open(url, function() {
     case 'WCAG2AAA':
       page.evaluate(() => HTMLCS_RUNNER.run('WCAG2AAA'));
       break;
+    case 'Section508':
+      page.evaluate(() => HTMLCS_RUNNER.run('Section508'));
+      break;
     default:
       console.log('Unknown standard.');
   }


### PR DESCRIPTION
Adding support for the `Section508` HTML_CodeSniffer `accessibilityLevel`. If you permit this quick tweak, the PR would close out issue https://github.com/yargalot/AccessSniff/issues/21.