### PR TITLE
fix headings in CSV and TXT reports

### DIFF
--- a/dist/reports.js
+++ b/dist/reports.js
@@ -89,7 +89,7 @@ var reports = exports.reports = function () {
     key: 'reportTxt',
     value: function reportTxt(reports) {
 
-      var output = 'heading, issue, element, line, column, description \n';
+      var output = 'heading, issue, element, id, class, line, column, description \n';
       var seperator = '|';
 
       _underscore2.default.each(reports, function (report) {
@@ -112,7 +112,7 @@ var reports = exports.reports = function () {
     key: 'reportCsv',
     value: function reportCsv(reports) {
 
-      var output = 'heading, issue, element, line, column, description \n';
+      var output = 'heading, issue, element, id, class, line, column, description \n';
       var seperator = ',';
 
       _underscore2.default.each(reports, function (report) {


### PR DESCRIPTION
When reporting to a CSV I realized that the column headers were not actually aligning with the columns properly, the **description** column for example was where the **line** output was going. 
I simply added a CSV column heading for **id** and **class**, I opened an issue in the gulp-accessibility project about 5 minutes ago before realizing it was a fairy easy fix in the AccessSniff project.

I also added the same headings into the TXT report.