### PR TITLE
Generate report using the "force" option, if errors were found

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,5 +223,8 @@ txt, csv, json.
 #### Report Location
 `-r` or `-reportLocation`
 
+#### Force
+`-f` or `-force`
+
 #### Quiet
 `-q` or `-quiet`

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -14,6 +14,7 @@ exports.setup = function(cliOptions) {
     .version(packageInfo.version)
     .option('-r, --reportType [reportType]', 'Report type [json]', 'json')
     .option('-l, --reportLocation [reportLocation]', 'Report Location [reports]', 'reports')
+    .option('-f, --force', 'No failure in case of errors')
     .option('-q, --quiet', 'No terminal output')
     .parse(cliOptions);
 
@@ -25,6 +26,10 @@ exports.setup = function(cliOptions) {
   // ADD IN REPORTS
   options.reportType = program.reportType;
   options.reportLocation = program.reportLocation;
+
+  if (program.force) {
+    options.force = true;
+  }
 
   if (program.quiet) {
     options.verbose = false;

--- a/src/reports/index.js
+++ b/src/reports/index.js
@@ -9,7 +9,7 @@ import GenerateReport from './generateReport';
 const defaultOptions = {
   fileName: 'report',
   reportType: 'json',
-  location: ''
+  reportLocation: ''
 };
 
 export default (reports, options = defaultOptions) => {
@@ -18,7 +18,7 @@ export default (reports, options = defaultOptions) => {
 
   let report = new ReportsGenerator(reports, options);
 
-  if (options.location) {
+  if (options.reportLocation) {
     report.writeFile();
   }
 
@@ -33,7 +33,7 @@ class ReportsGenerator {
     this.report = {
       name: options.fileName,
       type: options.reportType,
-      location: options.location,
+      location: options.reportLocation,
       output: ''
     };
 

--- a/test/reports.test.js
+++ b/test/reports.test.js
@@ -33,7 +33,7 @@ exports.accessibilityTests = {
   },
   report_JSON: test => {
     AccessSniff.default(['./test/examples/test.html'], options)
-      .then(report => AccessSniff.report(report, {location: 'reports'}))
+      .then(report => AccessSniff.report(report, {reportLocation: 'reports'}))
       .then(report => {
         var writtenReport = fs.readFileSync('./reports/report.json', 'utf8');
         var expected = fs.readFileSync('./test/expected/report.json', 'utf8');
@@ -47,7 +47,7 @@ exports.accessibilityTests = {
   },
   report_CSV: test => {
     AccessSniff.default(['./test/examples/test.html'], options)
-      .then(report => AccessSniff.report(report, {location: 'reports', reportType: 'csv', force: true}))
+      .then(report => AccessSniff.report(report, {reportLocation: 'reports', reportType: 'csv', force: true}))
       .then(report => {
         var writtenReport = fs.readFileSync('./reports/report.csv', 'utf8');
         var expected = fs.readFileSync('./test/expected/report.csv', 'utf8');
@@ -61,7 +61,7 @@ exports.accessibilityTests = {
   },
   report_TXT: test => {
     AccessSniff.default(['./test/examples/test.html'], options)
-      .then(report => AccessSniff.report(report, {location: 'reports', reportType: 'txt', force: true}))
+      .then(report => AccessSniff.report(report, {reportLocation: 'reports', reportType: 'txt', force: true}))
       .then(report => {
         var writtenReport = fs.readFileSync('./reports/report.txt', 'utf8');
         var expected = fs.readFileSync('./test/expected/report.txt', 'utf8');


### PR DESCRIPTION
Attempts to fix #41.

Add -f|--force command-line parameter for the script executable. Force not only the error exit code suppression, but also writing the report as an side-effect, if the source files contained errors.

Fix the report option "reportLocation". Externally documented interface should use "reportLocation", while the internal reporter generator wrapper uses "location". This will need a fix in Grunt and Gulp tasks too, which used an undocumented interface.